### PR TITLE
Fix jobs page event name

### DIFF
--- a/vue-frontend/src/components/JobsScreen.vue
+++ b/vue-frontend/src/components/JobsScreen.vue
@@ -71,7 +71,7 @@ export default {
     },
   },
   mounted() {
-    this.$gtag.event("view_page_home");
+    this.$gtag.event("view_page_jobs");
   },
 };
 </script>


### PR DESCRIPTION
Noticed the issue while looking at analytics data, there was no jobs page event.