### PR TITLE
Add robots.txt file

### DIFF
--- a/vue-frontend/public/robots.txt
+++ b/vue-frontend/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://canopas.com/sitemap.xml


### PR DESCRIPTION
1. what is `robots.txt` file and why we add `robots.txt` file in our website ?

- A `robots.txt` file tells search engine crawlers which URLs the crawler can access on our site. This is used mainly to avoid `overloading` your site with requests.
- Search engine  bots is not crawling our website so that's way we add the `robots.txt` file in our website.
