### PR TITLE
Remove Bootstrap css from contact us page and 404 error page

### DIFF
--- a/vue-frontend/src/assets/css/tailwind.css
+++ b/vue-frontend/src/assets/css/tailwind.css
@@ -19,3 +19,10 @@
   font-display: swap;
   src: url(./../fonts/FuturaLT-Bold.woff2);
 }
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  transition: background-color 5000s !important;
+}

--- a/vue-frontend/src/components/contact/CalendlyIframe.vue
+++ b/vue-frontend/src/components/contact/CalendlyIframe.vue
@@ -1,10 +1,13 @@
 <template>
-  <div class="calendly-iframe-div">
+  <div class="tw-w-full tw-h-[550px] tw-border-0 tw-pt-[20px] md:tw-h-[700px]">
     <div v-if="isLoading" class="iframe-loader">
-      <img :src="loader" class="loader-div" />
+      <img
+        :src="loader"
+        class="tw-fixed tw-left-[50%] tw-top-[50%] -tw-translate-y-1/2 -tw-translate-x-1/2 tw-z-[100]"
+      />
     </div>
     <iframe
-      class="calendly-iframe"
+      class="tw-h-full tw-w-full"
       :src="calendlyUrl"
       title="calendly"
       v-on:load="isLoading = false"
@@ -27,41 +30,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-.calendly-iframe-div {
-  width: 100%;
-  height: 550px;
-  border: none;
-  padding-top: 20px;
-}
-
-.loader-div {
-  position: fixed;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 100;
-}
-
-.iframe-div {
-  height: 100%;
-  width: 100%;
-  border: none !important;
-}
-
-.calendly-iframe {
-  height: 100%;
-  width: 100%;
-}
-
-.calendly-iframe::-webkit-scrollbar {
-  display: none;
-}
-
-@include media-breakpoint-up(md) {
-  .calendly-iframe-div {
-    height: 700px;
-  }
-}
-</style>

--- a/vue-frontend/src/components/contact/ContactForm.vue
+++ b/vue-frontend/src/components/contact/ContactForm.vue
@@ -1,12 +1,14 @@
 <template>
-  <div class="container">
+  <div class="tw-container -tw-mt-16 tw-mb-24">
     <form>
-      <div class="information-detail">
-        <div class="information-pd">
+      <div
+        class="tw-rounded-3xl tw-border tw-border-slate-200 tw-bg-white tw-shadow-3xl"
+      >
+        <div class="tw-py-5 tw-px-8 lg:tw-px-24">
           <div class="row">
             <div class="col-lg-6 col-md-6 col-sm-12 tw-pt-5">
               <input
-                class="custom-text-input v2-normal-text"
+                class="tw-w-full tw-py-3 tw-px-0 tw-my-2 tw-mx-0 tw-box-border tw-border-b tw-border-slate-400 tw-rounded-none focus:tw-box-border focus:tw-border-b focus:tw-border-slate-400 focus:tw-outline-none placeholder:tw-text-slate-400 v2-normal-text"
                 type="text"
                 name="username"
                 required
@@ -21,7 +23,7 @@
             </div>
             <div class="col-lg-6 col-md-6 col-sm-12 tw-pt-5">
               <input
-                class="custom-text-input v2-normal-text"
+                class="tw-w-full tw-py-3 tw-px-0 tw-my-2 tw-mx-0 tw-box-border tw-border-b tw-border-slate-400 tw-rounded-none focus:tw-box-border focus:tw-border-b focus:tw-border-slate-400 focus:tw-outline-none placeholder:tw-text-slate-400 v2-normal-text"
                 type="text"
                 name="email"
                 required
@@ -36,7 +38,7 @@
             </div>
             <div class="col-lg-12 col-md-12 col-sm-12 tw-pt-5 lg:tw-pt-14">
               <textarea
-                class="custom-text-input v2-normal-text"
+                class="tw-w-full tw-py-3 tw-px-0 tw-my-2 tw-mx-0 tw-box-border tw-border-b tw-border-slate-400 tw-rounded-none focus:tw-box-border focus:tw-border-b focus:tw-border-slate-400 focus:tw-outline-none placeholder:tw-text-slate-400 v2-normal-text"
                 name="project"
                 rows="1"
                 autocomplete="given-project-info"
@@ -47,7 +49,7 @@
             </div>
             <div class="col-lg-12 col-md-12 col-sm-12 tw-pt-5 lg:tw-pt-10">
               <input
-                class="custom-text-input v2-normal-text"
+                class="tw-w-full tw-py-3 tw-px-0 tw-my-2 tw-mx-0 tw-box-border tw-border-b tw-border-slate-400 tw-rounded-none focus:tw-box-border focus:tw-border-b focus:tw-border-slate-400 focus:tw-outline-none placeholder:tw-text-slate-400 v2-normal-text"
                 type="text"
                 name="reference"
                 required
@@ -76,13 +78,15 @@
                   v-model.number="contactType"
                   :disabled="disableInput"
                 />
-                <div class="contact-button tw-mb-6 sm:tw-mr-9 sm:tw-mb-0">
+                <div
+                  class="hover:tw-text-white v2-normal-3-text contact-button tw-flex tw-items-center tw-border tw-border-black-900 tw-rounded-lg tw-px-6 tw-py-2 hover:tw-bg-black-900 tw-mb-6 sm:tw-mr-9 sm:tw-mb-0 active:tw-scale-[0.98]"
+                >
                   <font-awesome-icon
-                    class="fa -tw-rotate-45 tw-w-6 tw-h-6 tw-text-black-900"
+                    class="-tw-rotate-45 tw-w-6 tw-h-6"
                     :icon="phone"
                     aria-hidden="true"
                   />
-                  <span class="tw-ml-5 v2-normal-3-text">Call</span>
+                  <span class="tw-ml-5">Call</span>
                 </div></label
               >
 
@@ -95,9 +99,11 @@
                   v-model.number="contactType"
                   :disabled="disableInput"
                 />
-                <div class="v2-normal-3-text contact-button">
+                <div
+                  class="hover:tw-text-white v2-normal-3-text contact-button tw-flex tw-items-center tw-border tw-border-black-900 tw-rounded-lg tw-px-6 tw-py-2 hover:tw-bg-black-900 active:tw-scale-[0.98]"
+                >
                   <font-awesome-icon
-                    class="fa tw-w-6 tw-h-6 tw-text-black-900"
+                    class="fa tw-w-6 tw-h-6"
                     :icon="mail"
                     aria-hidden="true"
                   />
@@ -116,7 +122,7 @@
             >
               <button
                 v-if="contactType == 1"
-                class="gradient-btn tw-py-4 tw-px-8 tw-m-0"
+                class="gradient-btn tw-w-80 tw-px-0 tw-py-4 tw-m-0"
                 @click.prevent="submitApplication()"
               >
                 <font-awesome-icon
@@ -128,7 +134,7 @@
               </button>
               <button
                 v-if="contactType == 2"
-                class="gradient-btn tw-py-4 tw-px-8 tw-m-0"
+                class="gradient-btn tw-w-80 tw-px-0 tw-py-4 tw-m-0"
                 @click.prevent="submitApplication()"
               >
                 <font-awesome-icon
@@ -146,18 +152,22 @@
     <!-- Show Calendly Iframe -->
     <div v-if="openCalendlyIframeModal">
       <transition name="modal">
-        <div class="modal-mask mask">
+        <div
+          class="modal-mask tw-fixed tw-top-0 tw-left-0 tw-w-full tw-h-full tw-table mask tw-z-[1] tw-bg-[#00000080]"
+        >
           <div
             class="modal-dialog login-modal modal-xl modal-dialog-centered"
             role="document"
           >
-            <div class="modal-content calendly-iframe-modal-content">
+            <div
+              class="modal-content tw-p-2.5 tw-rounded-3xl calendly-iframe-modal-content"
+            >
               <div class="modal-body">
                 <CalendlyIframe />
 
                 <button
                   type="button"
-                  class="close modal-close-btn"
+                  class="close modal-close-btn tw-border-none tw-text-pink-300 tw-text-4xl tw-font-light tw-bg-transparent tw-absolute tw-right-2.5 tw-top-0 focus:tw-outline-none"
                   data-dismiss="modal"
                   aria-label="Close"
                 >
@@ -174,9 +184,11 @@
     <!-- Show Thank you message -->
     <div v-if="showSuccessMessagePopup">
       <transition name="modal">
-        <div class="modal-mask mask">
+        <div
+          class="modal-mask tw-fixed tw-top-0 tw-left-0 tw-w-full tw-h-full tw-table mask tw-z-[1] tw-bg-[#00000080]"
+        >
           <div class="modal-dialog modal-dialog-centered" role="document">
-            <div class="modal-content">
+            <div class="modal-content tw-p-2.5 tw-rounded-3xl">
               <div class="modal-header">
                 <div class="normal-text canopas-gradient-text text-center">
                   Thank you for choosing us to make a difference in your
@@ -197,9 +209,13 @@
     <!-- Show error message -->
     <div v-if="showErrorMessagePopup">
       <transition name="modal">
-        <div class="modal-mask mask">
+        <div
+          class="modal-mask tw-fixed tw-top-0 tw-left-0 tw-w-full tw-h-full tw-table mask tw-z-[1] tw-bg-[#00000080]"
+        >
           <div class="modal-dialog modal-dialog-centered" role="document">
-            <div class="modal-content calendly-iframe-modal-content">
+            <div
+              class="modal-content tw-p-2.5 tw-rounded-3xl calendly-iframe-modal-content"
+            >
               <div class="modal-header tw-justify-center">
                 <div class="header-2-text canopas-gradient-text">Error</div>
               </div>
@@ -209,7 +225,7 @@
                 </div>
                 <div class="close-btn-div">
                   <button
-                    class="gradient-btn tw-float-right"
+                    class="gradient-btn tw-w-80 tw-px-0 tw-float-right"
                     @click.prevent="showErrorMessagePopup = false"
                   >
                     <span>Close</span>
@@ -325,87 +341,3 @@ export default {
   },
 };
 </script>
-
-<style lang="postcss" scoped>
-.container {
-  @apply -tw-mt-16 tw-mb-24;
-}
-
-.information-detail {
-  @apply tw-rounded-3xl tw-border tw-border-slate-200 tw-bg-white tw-shadow-3xl;
-}
-
-.information-pd {
-  @apply tw-py-5 tw-px-8 lg:tw-px-24;
-}
-
-.custom-text-input {
-  @apply tw-w-full tw-py-3 tw-px-0 tw-my-2 tw-mx-0 tw-box-border tw-border-b tw-border-slate-400 tw-rounded-none;
-}
-
-.custom-text-input:focus {
-  @apply tw-box-border  tw-border-b tw-border-slate-400 tw-outline-none;
-}
-
-.custom-file-input {
-  @apply tw-w-0 tw-p-0 tw-opacity-0;
-}
-
-.v2-title-2-text {
-  @apply tw-leading-9 lg:tw-leading-11;
-}
-
-.contact-button {
-  @apply tw-flex tw-items-center tw-border tw-border-black-900 tw-rounded-lg tw-px-6 tw-py-2  hover:tw-bg-black-900;
-}
-
-.contact-button:hover > span,
-.contact-button:hover > .fa {
-  @apply tw-text-white;
-}
-
-.contact-button-active {
-  @apply tw-bg-black-900  hover:tw-bg-white;
-}
-
-.contact-button:active {
-  transform: scale(0.98);
-}
-
-.gradient-btn {
-  @apply tw-w-80 tw-px-0;
-}
-
-input:-webkit-autofill,
-input:-webkit-autofill:hover,
-input:-webkit-autofill:focus,
-input:-webkit-autofill:active {
-  transition: background-color 5000s !important;
-}
-
-.modal-content {
-  @apply tw-p-2.5 tw-rounded-3xl;
-}
-
-.modal-close-btn {
-  @apply tw-border-none tw-text-pink-300 tw-text-4xl tw-font-light tw-bg-transparent tw-absolute tw-right-2.5 tw-top-0;
-}
-
-.modal-close-btn:focus {
-  @apply tw-outline-none;
-}
-
-.modal-mask {
-  @apply tw-fixed tw-top-0 tw-left-0 tw-w-full tw-h-full tw-table;
-}
-
-.mask {
-  z-index: 1;
-  background-color: rgba(0, 0, 0, 0.5);
-  transition: opacity 0.3s ease;
-}
-
-::placeholder {
-  @apply tw-text-slate-400;
-}
-</style>

--- a/vue-frontend/src/components/contact/ContactLanding.vue
+++ b/vue-frontend/src/components/contact/ContactLanding.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="background">
+  <div
+    class="background tw-from-[#f983860d] tw-to-[#f983860d] tw-bg-gradient-270 tw-shadow-[0px_4px_2px_1px_rgba(0,0,0,5%)] tw-z--1"
+  >
     <div class="container tw-pb-24 tw-pt-10 sm:tw-pt-20">
       <div class="tw-flex tw-items-center">
         <div
@@ -61,15 +63,3 @@ export default {
   },
 };
 </script>
-
-<style lang="postcss" scoped>
-.background {
-  background: linear-gradient(
-    270.11deg,
-    rgba(249, 131, 134, 0.05) -24.42%,
-    rgba(249, 131, 134, 0.05) 101.76%
-  );
-  box-shadow: 0px 4px 2px 1px rgba(0, 0, 0, 5%);
-  z-index: -1;
-}
-</style>

--- a/vue-frontend/src/components/error404/index.vue
+++ b/vue-frontend/src/components/error404/index.vue
@@ -6,18 +6,30 @@
       </template>
     </metainfo>
     <ScreenHeaderV2 />
-    <div class="container">
-      <div class="image-404">
+    <div
+      class="tw-container tw-flex tw-items-center tw-justify-center tw-flex-col tw-my-0 tw-mx-auto tw-py-[150px] tw-px-[5%] tw-min-h-[50vh]"
+    >
+      <div class="tw-flex tw-flex-row tw-my-0 tw-mx-auto tw-text-center">
         <img :src="firstErrorLetter" alt="404" />
-        <img :src="middleErrorLetter" class="middle-logo" alt="404" />
+        <img :src="middleErrorLetter" class="tw-m-4 tw-w-[6.5rem]" alt="404" />
         <img :src="lastErrorLetter" alt="404" />
       </div>
-      <div class="middle-text">
+      <div class="tw-mt-[2rem] tw-text-center tw-text-[1.4rem] tw-leading-8">
         The page you’re looking for was moved, renamed or might never existed.
       </div>
-      <router-link class="back-btn gradient-border-btn" to="/">
-        <font-awesome-icon class="arrow" icon="arrow-left" id="leftArrow" />
-        <span class="canopas-gradient-text">Back to Home page</span>
+      <router-link
+        class="tw-w-auto tw-py-[1rem] tw-px-[1.5rem] tw-my-[7%] tw-mx-auto tw-border-[1rem] tw-border-solid tw-border-transparent tw-rounded-[10px] tw-flex tw-justify-around tw-items-center gradient-border-btn"
+        to="/"
+      >
+        <font-awesome-icon
+          class="fa tw-text-[#f2709c] tw-text-[1.5rem] tw-mr-[16px]"
+          icon="arrow-left"
+          id="leftArrow"
+        />
+        <span
+          class="canopas-gradient-text tw-text-center tw-font-bold tw-text-[1.1rem]"
+          >Back to Home page</span
+        >
       </router-link>
     </div>
     <ScreenFooter2 />
@@ -64,68 +76,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-.container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-  margin: 0 auto;
-  padding: 150px 5%;
-  min-height: 50vh;
-}
-
-.image-404 {
-  margin: 0 auto;
-  text-align: center;
-  display: flex;
-  flex-direction: row;
-}
-
-.middle-text {
-  margin-top: 2rem;
-  text-align: center;
-  font-size: 1.4rem !important;
-  line-height: 2rem !important;
-}
-
-.middle-logo {
-  margin: 1rem;
-  width: 6.5rem;
-}
-
-.back-btn,
-.back-btn:hover,
-.back-btn:focus {
-  width: auto;
-  padding: 1rem 1.5rem !important;
-  margin: 7% auto;
-  border: 1px solid transparent;
-  border-radius: 10px;
-  display: flex;
-  justify-content: space-around !important;
-  align-items: center;
-  text-decoration: none;
-}
-
-.back-btn > span {
-  text-align: center !important;
-  font-weight: 700;
-  font-size: 1.1rem !important;
-}
-
-.black {
-  color: rgba(61, 61, 61, 1);
-}
-
-.back-btn > i {
-  margin-right: 1rem;
-}
-
-.arrow {
-  color: #f2709c;
-  font-size: 1.5rem;
-  margin-right: 16px;
-}
-</style>

--- a/vue-frontend/tailwind.config.cjs
+++ b/vue-frontend/tailwind.config.cjs
@@ -93,6 +93,7 @@ module.exports = {
       },
       bgGradientDeg: {
         247: "247.22deg",
+        270: "270.11deg",
       },
     },
   },


### PR DESCRIPTION
Remove Bootstrap css 

1. 404 Error page 
2. Calendly Iframe
3. Refactor contact us landing page and form page css 