### PR TITLE
Fix career and portfolio page performance

### DIFF
--- a/vue-frontend/src/components/contact/ContactLanding.vue
+++ b/vue-frontend/src/components/contact/ContactLanding.vue
@@ -5,7 +5,11 @@
     <div class="tw-container tw-pb-24 tw-pt-10 sm:tw-pt-20">
       <div class="tw-flex tw-items-center v2-title-2-text tw-font-bold">
         <div class="v2-canopas-gradient-text tw-mr-4">Hey Smarty</div>
-        <img :src="HandWing" class="tw-w-8 tw-h-8 lg:tw-w-12 lg:tw-h-12" />
+        <img
+          :src="HandWing"
+          alt="HandWing"
+          class="tw-w-8 tw-h-8 lg:tw-w-12 lg:tw-h-12"
+        />
       </div>
       <div class="v2-normal-text tw-pt-8">
         Thanks for reaching out to us. We're happy to help you achieve your

--- a/vue-frontend/src/components/home-new/BlogSection.vue
+++ b/vue-frontend/src/components/home-new/BlogSection.vue
@@ -23,7 +23,7 @@
               :src="backgroundImage"
               class="tw-hidden md:tw-block tw-pt-12 tw-h-full tw-w-[260px]"
               loading="lazy"
-              alt="blog-background"
+              alt="blog-background-image"
             />
           </div>
         </div>
@@ -49,6 +49,7 @@
               :src="blog.thumbnail"
               class="tw-w-full tw-h-full tw-object-cover tw-rounded-t-x-lg"
               loading="lazy"
+              :alt="blog.title"
             />
           </aspect-ratio>
           <div

--- a/vue-frontend/src/components/home-new/ContributeSection.vue
+++ b/vue-frontend/src/components/home-new/ContributeSection.vue
@@ -43,6 +43,7 @@
           :src="contribution.image"
           class="tw-w-full tw-h-full tw-object-cover tw-rounded-[10px]"
           loading="lazy"
+          :alt="contribution.alt"
         />
 
         <div class="tw-w-full tw-p-[20px] v2-title-3-text">
@@ -84,11 +85,13 @@ export default {
           image: introShowcase,
           bgColor: "#FAF5F2",
           link: "https://github.com/canopas/Intro-showcase-view",
+          alt: "introShowcase",
         },
         {
           image: uiPilot,
           bgColor: "#3D3D3D",
           link: "https://github.com/canopas/UIPilot",
+          alt: "uiPilot",
         },
       ],
     };

--- a/vue-frontend/src/components/home-new/PortfolioSection.vue
+++ b/vue-frontend/src/components/home-new/PortfolioSection.vue
@@ -18,7 +18,6 @@
             :srcset="`${portfolio.images[0]} 400w, ${portfolio.images[1]} 800w, ${portfolio.images[2]} 1200w, ${portfolio.images[3]} 1600w`"
             sizes="(min-width: 992px) 45vw, 100vw"
             class="tw-w-full tw-h-full tw-object-cover"
-            loading="lazy"
             :alt="portfolio.title + `-image`"
           />
         </div>

--- a/vue-frontend/src/components/jobs/CareerView.vue
+++ b/vue-frontend/src/components/jobs/CareerView.vue
@@ -85,6 +85,7 @@
                   @click.native="$gtag.event('tap_read_more_job')"
                   class="gradient-border-btn tw-p-[11px] sm:tw-p-[16px]"
                   :to="'/jobs/' + career.unique_id"
+                  aria-label="read-more"
                 >
                   <font-awesome-icon
                     class="fa tw-text-pink-300"

--- a/vue-frontend/src/components/jobs/FaqSection.vue
+++ b/vue-frontend/src/components/jobs/FaqSection.vue
@@ -85,6 +85,7 @@
               class="clients-indicators tw-bg-none tw-border-none tw-my-0 tw-mx-[8px] tw-cursor-pointer"
               @click="slide(-1)"
               @click.native="$gtag.event('tap_faq_previous_arrow')"
+              aria-label="leftArrow"
             >
               <font-awesome-icon
                 class="arrow tw-border-[1px] tw-border-solid tw-border-[#3d3d3d26] tw-rounded-[15px] tw-h-[25px] tw-w-[25px] tw-p-[10px] tw-text-[#fff] tw-bg-black-900"
@@ -99,6 +100,7 @@
               class="clients-indicators tw-bg-none tw-border-none tw-my-0 tw-mx-[8px] tw-cursor-pointer"
               @click="slide(1)"
               @click.native="$gtag.event('tap_faq_next_arrow')"
+              aria-label="rightArrow"
             >
               <font-awesome-icon
                 class="arrow tw-border-[1px] tw-border-solid tw-border-[#3d3d3d26] tw-rounded-[15px] tw-h-[25px] tw-w-[25px] tw-p-[10px] tw-text-[#fff] tw-bg-black-900"

--- a/vue-frontend/src/components/jobs/VirtuesView.vue
+++ b/vue-frontend/src/components/jobs/VirtuesView.vue
@@ -11,7 +11,7 @@
           class="tw-relative tw-flex-[100%] md:tw-flex-[33%]"
           v-for="virtue in virtues.slice(0, 3)"
           :key="virtue.id"
-          @touchstart="activeIndex = virtue.id"
+          @touchstart.passive="activeIndex = virtue.id"
           @hover.native="$gtag.event('hover_virtue')"
         >
           <div
@@ -57,7 +57,7 @@
           class="tw-relative tw-flex-[100%] md:tw-flex-[33%]"
           v-for="virtue in virtues.slice(3, 5)"
           :key="virtue.id"
-          @touchstart="activeIndex = virtue.id"
+          @touchstart.passive="activeIndex = virtue.id"
           @hover.native="$gtag.event('hover_virtue')"
         >
           <div
@@ -101,7 +101,7 @@
           class="tw-relative tw-flex-[100%] md:tw-flex-[33%]"
           v-for="virtue in virtues.slice(5, 8)"
           :key="virtue.id"
-          @touchstart="activeIndex = virtue.id"
+          @touchstart.passive="activeIndex = virtue.id"
           @hover.native="$gtag.event('hover_virtue')"
         >
           <div
@@ -147,7 +147,7 @@
           class="tw-relative tw-flex-[100%] md:tw-flex-[33%]"
           v-for="virtue in virtues.slice(8, 10)"
           :key="virtue.id"
-          @touchstart="activeIndex = virtue.id"
+          @touchstart.passive="activeIndex = virtue.id"
           @hover.native="$gtag.event('hover_virtue')"
         >
           <div

--- a/vue-frontend/src/components/partials/ScreenFooter2.vue
+++ b/vue-frontend/src/components/partials/ScreenFooter2.vue
@@ -13,6 +13,7 @@
       <div class="tw-mb-16 xl:tw-mb-24" v-if="isJobsUrl">
         <a
           :href="glassdoorLink"
+          aria-label="glassdoorLink"
           @click.native="$gtag.event('tap_glassdoor_review')"
         >
           <img
@@ -45,12 +46,14 @@
               :href="socialMedia.url"
               target="_blank"
               @click.native="$gtag.event(socialMedia.event)"
+              aria-label="footerLink"
               ><img
                 class="active:tw-scale-[0.98] tw-h-full tw-w-full"
                 v-if="socialMedia.image"
                 :src="hover ? designRushHover : designRush"
                 @mouseover="hover = true"
                 @mouseleave="hover = false"
+                alt="designrush-icon"
               />
               <font-awesome-icon
                 v-else

--- a/vue-frontend/vite.config.js
+++ b/vue-frontend/vite.config.js
@@ -26,13 +26,6 @@ export default defineConfig({
       },
     },
   },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        additionalData: `@import "@/assets/scss/custom.scss";`,
-      },
-    },
-  },
   plugins: [vuePlugin(), Pages()],
   build: {
     rollupOptions: {


### PR DESCRIPTION
Solve lighthouse Errors to improve performance on CAREER and PORTFOLIO PAGE in mobile.
CAREER PAGE:
Previous: 89
**Now: 91-92 approx.**

PORTFOLIO PAGE:
Previous: 85
**Now: 98**

**Issues solved:**
- [x]  Links do not have a discernible name.
- [x]  Does not use passive listeners to improve scrolling performance
- [x]  Eliminate render-blocking resources.
- [x]  Background and foreground colors do not have a sufficient contrast ratio.
- [x]  Links do not have descriptive text 

**PORFOLIO PAGE:
Issues solved:**

- [x] Largest Contentful Paint image was lazily loaded