### PR TITLE
Add form success events for fb

### DIFF
--- a/vue-frontend/src/components/contact/ContactForm.vue
+++ b/vue-frontend/src/components/contact/ContactForm.vue
@@ -390,6 +390,7 @@ export default {
                 .post(config.API_BASE + "/api/send-contact-mail", formData)
                 .then(() => {
                   this.showLoader = true;
+                  fbq("track", "contact_form_submit_success");
                   if (this.contactType == CONTACT_BY_CHAT_OR_MAIL) {
                     setTimeout(() => {
                       this.showSuccessMessage();

--- a/vue-frontend/src/components/contact/ContactFormFooter.vue
+++ b/vue-frontend/src/components/contact/ContactFormFooter.vue
@@ -403,6 +403,7 @@ export default {
                   .post(config.API_BASE + "/api/send-contact-mail", formData)
                   .then(() => {
                     setTimeout(() => {
+                      fbq("track", "footer_form_submit_success");
                       this.showSuccessMessagePopup = true;
                       this.showLoader = false;
                     }, 1000);


### PR DESCRIPTION
**Tested on:**
- [ ] Inspector (all iPhones and android devices like samsung, motorola)
- [ ] Desktop (chrome, firefox, safari)
- [ ] Laptop / Macbook  (chrome, firefox, safari)
- [ ] iPhone(safari)
- [ ] Available android devices  (chrome, firefox)
- [ ] iPad(safari)
- [ ] Tablet (chrome, firefox)

**This is event specific PR. No need to check in all devices**
