### PR TITLE
Feat: Redirect blogs to resources

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build nginx and push on ECR
         run: |
           cd nginx 
+          sed -i.bak -e '10,15d' conf.d/default.conf && rm conf.d/default.conf.bak
           sed -i "s|WEBSITE_URL|canopas.com|g" conf.d/default.conf
           sed -i "s|API_URL|prod-stack-api.canopas.com|g" conf.d/default.conf
           bash ./../deploy/deploy-ecr-image.sh prod-nginx ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.$AWS_REGION.amazonaws.com/canopas-website-nginx

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -7,6 +7,12 @@ server {
         proxy_pass         http://canopas-website-frontend:3080;
         proxy_set_header   Host $host;
     }
+
+    location /resources {
+        proxy_ssl_server_name on;
+        proxy_pass         https://articles.canopas.com;
+        proxy_set_header   Host articles.canopas.com;
+    }
 }
 
 server {

--- a/vue-frontend/src/components/contact/NewContactLanding.vue
+++ b/vue-frontend/src/components/contact/NewContactLanding.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tw-px-2">
+  <div class="tw-pr-2">
     <div
       class="tw-flex tw-items-center tw-py-7 md:tw-py-12 lg:tw-pb-5 lg:tw-pt-0 tw-font-product-sans tw-font-bold tw-text-[1.875rem] md:tw-text-[2.5rem] tw-leading-[2.274375rem] md:tw-leading-[3.0325rem]"
     >

--- a/vue-frontend/src/components/partials/NewHeader.vue
+++ b/vue-frontend/src/components/partials/NewHeader.vue
@@ -19,7 +19,7 @@
         ref="mainHeader"
       >
         <div
-          class="tw-container tw-flex tw-flex-col lg:tw-flex-row tw-flex-wrap lg:tw-flex-nowrap tw-items-start lg:tw-items-center"
+          class="tw-container tw-flex tw-flex-col xl:tw-flex-row tw-flex-wrap xl:tw-flex-nowrap tw-items-start xl:tw-items-center"
         >
           <router-link to="/" replace>
             <div
@@ -42,7 +42,7 @@
               <li
                 v-for="navbar in navbars"
                 :key="navbar"
-                class="tw-my-2 sm:tw-my-0 tw-ml-0"
+                class="tw-my-2 tw-ml-0"
               >
                 <router-link
                   v-if="!navbar.target"
@@ -52,12 +52,9 @@
                   :class="[
                     navbar.className
                       ? navbar.className
-                      : 'tw-inline-block tw-relative tw-mr-[20px] sm:tw-mr-[30px] after:tw-absolute after:tw-w-full after:tw-h-[3px] after:tw-top-[27px] after:tw-bottom-0 after:tw-left-0 after:tw-bg-pink-300 after:tw-origin-bottom-left after:tw-duration-300 after:tw-scale-x-0 hover:after:tw-scale-x-100 hover:after:tw-origin-bottom-left hover:tw-bg-clip-text hover:tw-bg-gradient-[270.11deg] hover:tw-from-[#ff9472] hover:tw-to-[#f2709c] hover:tw-text-transparent',
-                    currentRoutePath == navbar.url ||
-                    (navbar.name == 'Portfolio' &&
-                      currentRoutePath.includes('portfolio')) ||
-                    (navbar.name == 'Career' &&
-                      currentRoutePath.includes('jobs'))
+                      : navbar.class +
+                        ' after:tw-absolute after:tw-w-full after:tw-h-[3px] after:tw-top-[27px] after:tw-bottom-0 after:tw-left-0 after:tw-bg-pink-300 after:tw-origin-bottom-left after:tw-duration-300 after:tw-scale-x-0 hover:after:tw-scale-x-100 hover:after:tw-origin-bottom-left hover:tw-bg-clip-text hover:tw-bg-gradient-[270.11deg] hover:tw-from-[#ff9472] hover:tw-to-[#f2709c] hover:tw-text-transparent',
+                    currentRoutePath.includes(navbar.url)
                       ? navbar.showContactBtn
                         ? ''
                         : 'after:tw-w-full after:tw-scale-x-0 after:tw-scale-x-100'
@@ -76,7 +73,7 @@
                   v-else
                   class="tw-inline-block tw-relative tw-mr-[20px] sm:tw-mr-[30px] after:tw-absolute after:tw-w-full after:tw-h-[3px] after:tw-top-[27px] after:tw-bottom-0 after:tw-left-0 after:tw-bg-pink-300 after:tw-origin-bottom-left after:tw-duration-300 after:tw-scale-x-0 hover:after:tw-scale-x-100 hover:after:tw-origin-bottom-left hover:tw-bg-clip-text hover:tw-bg-gradient-[270.11deg] hover:tw-from-[#ff9472] hover:tw-to-[#f2709c] hover:tw-text-transparent"
                   :href="navbar.url"
-                  target="_blank"
+                  :target="navbar.target"
                   >{{ navbar.name }}</a
                 >
               </li>
@@ -107,20 +104,21 @@ export default {
           event: "tap_header_portfolio",
         },
         {
-          name: "Blog",
-          url: Config.BLOG_URL,
-          target: true,
-          event: "tap_header_blog",
-        },
-        {
           name: "Career",
           url: "/jobs",
           event: "tap_header_career",
         },
         {
+          name: "Blog",
+          url: Config.BLOG_URL,
+          target: "_blank",
+          event: "tap_header_blog",
+        },
+
+        {
           name: "Let's talk",
           url: "/contact",
-          className: "lg:tw-hidden",
+          class: "lg:tw-hidden",
           event: "tap_header_cta",
         },
         {
@@ -147,6 +145,14 @@ export default {
         name: "Services",
         url: "/services",
         event: "tap_header_services",
+      });
+    }
+    if (Config.SHOW_RESOURCES_PAGE) {
+      this.navbars.splice(3, 0, {
+        name: "Resources",
+        url: "/resources",
+        target: "_self",
+        event: "tap_header_resources",
       });
     }
     if (

--- a/vue-frontend/src/components/services/LandingSection.vue
+++ b/vue-frontend/src/components/services/LandingSection.vue
@@ -66,6 +66,8 @@ import bg400w from "@/assets/images/services/bg/bg-400w.webp";
 import bg800w from "@/assets/images/services/bg/bg-800w.webp";
 import bg1200w from "@/assets/images/services/bg/bg-1200w.webp";
 import bg1600w from "@/assets/images/services/bg/bg-1600w.webp";
+import AspectRatio from "@/components/utils/AspectRatio.vue";
+
 export default {
   data() {
     return {
@@ -73,6 +75,9 @@ export default {
       landingImages: [landing400w, landing800w, landing1200w, landing1400w],
       bgImages: [bg400w, bg800w, bg1200w, bg1600w],
     };
+  },
+  components: {
+    AspectRatio,
   },
   mounted() {
     this.width = window.innerWidth;

--- a/vue-frontend/src/config.js
+++ b/vue-frontend/src/config.js
@@ -69,6 +69,7 @@ export default Object.freeze({
   WEBSITE_OPEN_SOURCE_URL: "https://github.com/canopas/canopas-website",
   SHOW_SMILEPLUS_PORTFOLIO: true,
   SHOW_ABOUT_US_PAGE: true,
+  SHOW_RESOURCES_PAGE: true,
   SHOW_SERVICES_PAGE: true,
   MIX_PANEL_TOKEN: "acf7239a736ff487ca6058c981a55d7e",
 });

--- a/vue-frontend/src/config.prod.js
+++ b/vue-frontend/src/config.prod.js
@@ -69,6 +69,7 @@ export default Object.freeze({
   WEBSITE_OPEN_SOURCE_URL: "https://github.com/canopas/canopas-website",
   SHOW_SMILEPLUS_PORTFOLIO: false,
   SHOW_ABOUT_US_PAGE: false,
+  SHOW_RESOURCES_PAGE: false,
   SHOW_SERVICES_PAGE: false,
   MIX_PANEL_TOKEN: "16b177c2cda3ec1fb11c63a07f27996c",
 });

--- a/vue-frontend/src/pages/contact.vue
+++ b/vue-frontend/src/pages/contact.vue
@@ -9,7 +9,9 @@
     <SuccessMessage v-if="message" />
     <ScreenLoader v-if="isLoading" v-bind:loader="true" />
 
-    <div class="tw-container lg:tw-flex lg:tw-flex-row lg:tw-mt-20">
+    <div
+      class="tw-container lg:tw-flex lg:tw-flex-row tw-mt-10 md:tw-mt-0 lg:tw-mt-20"
+    >
       <NewContactLanding class="tw-basis-3/6 2xl:tw-basis-[40%]" />
       <NewContactForm
         @showMessage="showSuccessMessage"


### PR DESCRIPTION
**Tested on:**
- [x] Inspector (all iPhones and Android devices like Samsung, and Motorola)
- [x] Desktop (chrome, firefox, safari)
- [x] Laptop / Macbook  (chrome, firefox, safari)
- [ ] iPhone(Safari)
- [ ] Available Android devices  (chrome, firefox)
- [ ] iPad(Safari)
- [ ] Tablet (chrome, firefox)

**Notes:** 
- Added resources menu in the header
- It's only visible on dev-stack as it's under a feature flag currently
- resources will redirect to articles.canopas.com
- Fixes
    -  fix underlining in the contact menu in mobile
    -  fix the top margin of the contact page on mobiles
