### PR TITLE
Removing background section titles on the homepage to make it consist…

### DIFF
--- a/nuxt-frontend/components/home-new/BlogSection.vue
+++ b/nuxt-frontend/components/home-new/BlogSection.vue
@@ -8,7 +8,7 @@
   >
     <div class="container flex flex-col items-center m-auto w-full">
       <div class="container">
-        <p class="text-white-smoke background-text text-center">Blogs</p>
+        <p class="hidden text-white-smoke background-text text-center">Blogs</p>
         <h2
           class="-mt-5 md:mt-[-50px] mx-auto lg:w-[71%] xl:w-[65%] mobile-header-2 lg:desk-header-2 text-center"
         >

--- a/nuxt-frontend/components/home-new/CaseStudy.vue
+++ b/nuxt-frontend/components/home-new/CaseStudy.vue
@@ -6,7 +6,7 @@
   >
     <div>
       <p
-        class="text-[#F8F8F8] background-text text-center"
+        class="hidden text-[#F8F8F8] background-text text-center"
         :class="currentRoutePath == '/portfolio' ? 'hidden' : 'block'"
       >
         Our Portfolio

--- a/nuxt-frontend/components/home-new/ServiceSection.vue
+++ b/nuxt-frontend/components/home-new/ServiceSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mt-60">
-    <p class="text-center background-text text-[#F8F8F8]">Services</p>
+    <p class="hidden text-center background-text text-[#F8F8F8]">Services</p>
     <p
       class="-mt-10 pb-16 text-center mobile-header-2 lg:desk-header-2 text-black-87 md:pb-24 xl:mt-[-50px]"
     >


### PR DESCRIPTION
Hi! I noticed that here are section titles (Services, Our Portfolio, and Blogs) behind the section headers ("Case studies", "Do we have a team with the right skills?", "How we can help you"). I would suggest hiding them completely to make it consistent with the last header ("We are here to contribute") or making the titles a separate component (Make them more readable). 

## Review checklist

**Note:** Make sure all points should be checked before submiting PR for review, otherwise PR will be cosidered invalid.

- [ ] Follow guidelines for creating branch name, adding commit messages or PR title
- [ ] Add MR description if applicable
- [ ] Follow guidelines for naming conventions everywhere (i.e files/folders, data structures)
- [ ] Reuse code (if the same code is written twice, make it common and reuse it at both places)
- [ ] Remove unused or commented code if not required
- [ ] Make MR self-approved - review MR as a reviewer and give it self-approval if everything is ok, if not make the required changes
- [ ] In progress MR should be marked as draft
- [ ] Make MR mark as ready before submitting it for review
- [ ] Add images, videos, or gifs of UI
- [ ] Add page speed score screenshot of UI (It should be > 85 for mobile and > 90 for desktops)

**Design should be tested on:**

- [ ] Inspector (all iPhones and android devices like samsung, motorola)
- [ ] Desktop (chrome, firefox, safari)
- [ ] Laptop / Macbook (chrome, firefox, safari)
- [ ] iPhone(safari)
- [ ] Available android devices (chrome, firefox)
- [ ] iPad(safari)
- [ ] Tablet (chrome, firefox)
